### PR TITLE
Correct typo Masachusettes -> Massachusetts

### DIFF
--- a/109-488-1-ED/2nd Edition/tblGazetteer.txt
+++ b/109-488-1-ED/2nd Edition/tblGazetteer.txt
@@ -1104,7 +1104,7 @@ ID*Gazetteer*L1 code*L2 code*L3 code*L4 code*Kew region code*Kew region subdivis
 1393*Mas a Tierra*8,00*85,00*JNF*JNF-OO*18,00**Temperate South America*Robinson Crusoe I.*
 1394*Mas Afuera*8,00*85,00*JNF*JNF-OO*18,00**Temperate South America*Alejandro Selkirk I.*
 1395*Masalembu Besar*4,00*42,00*JAW*JAW-OO*6,00*C*Malay Islands**
-1396*Masachusettes*7,00*75,00*MAS*MAS-OO*13,00**North America**
+1396*Massachusetts*7,00*75,00*MAS*MAS-OO*13,00**North America**
 1397*Mato Grosso*8,00*84,00*BZC*BZC-MT*16,00**East Tropical South America**
 1398*Mato Grosso do Sul*8,00*84,00*BZC*BZC-MS*16,00**East Tropical South America**
 1399*Matthew Is.*6,00*60,00*NWC*NWC-OO*9,00*B*New Caledonia**

--- a/109-488-1-ED/2nd Edition/tblLevel3.txt
+++ b/109-488-1-ED/2nd Edition/tblLevel3.txt
@@ -179,7 +179,7 @@ MAG*Magadan*31,00*RU**
 MAI*Maine*75,00*US**
 MAN*Manitoba*71,00*CA**
 MAQ*Macquarie Is.*90,00*AU**
-MAS*Masachusettes*75,00*US**
+MAS*Massachusetts*75,00*US**
 MAU*Mauritius*29,00*MU**
 MCI*Mozambique Channel Is.*29,00*RE**
 MCS*Marcus I.*62,00*JP**

--- a/109-488-1-ED/2nd Edition/tblLevel4.txt
+++ b/109-488-1-ED/2nd Edition/tblLevel4.txt
@@ -336,7 +336,7 @@ MAG-OO*Magadan*MAG*RU**
 MAI-OO*Maine*MAI*US**
 MAN-OO*Manitoba*MAN*CA**
 MAQ-OO*Macquarie Is.*MAQ*AU**
-MAS-OO*Masachusettes*MAS*US**
+MAS-OO*Massachusetts*MAS*US**
 MAU-OO*Mauritius*MAU*MU**
 MCI-OO*Mozambique Channel Is.*MCI*RE**
 MCS-OO*Marcus I.*MCS*JP**


### PR DESCRIPTION
Reported via email by Marc Riera. Is written correctly in the pdf: https://github.com/tdwg/wgsrpd/blob/master/109-488-1-ED/2nd%20Edition/TDWG_geo2.pdf